### PR TITLE
Improve support for rectangle images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,16 @@ name: Python CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main, dev]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     name: Python ${{ matrix.python-version }}
     env:
       PIPENV_VERBOSITY: -1
@@ -24,5 +24,4 @@ jobs:
           cache: poetry
       - run: poetry install
       - run: make test
-      - run: pipx install codecov
-      - run: codecov
+      - uses: codecov/codecov-action@v3

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ format-check:
 	poetry run black --check ${SRC_DIR} && poetry run isort -c ${SRC_DIR}
 
 test: lint format-check
-	poetry run pytest
+	poetry run pytest --cov-report=term --cov-report=xml:coverage.xml
 
 test-benchmark:
 	poetry run pytest --benchmark-only --benchmark-max-time=5 --benchmark-columns="mean,stddev,min,max"

--- a/pilgram/__init__.py
+++ b/pilgram/__init__.py
@@ -15,25 +15,39 @@
 from pilgram._1977 import _1977
 from pilgram._version import __version__
 from pilgram.aden import aden
+from pilgram.amaro import amaro
+from pilgram.ashby import ashby
 from pilgram.brannan import brannan
 from pilgram.brooklyn import brooklyn
+from pilgram.charmes import charmes
 from pilgram.clarendon import clarendon
+from pilgram.crema import crema
+from pilgram.dogpatch import dogpatch
 from pilgram.earlybird import earlybird
 from pilgram.gingham import gingham
+from pilgram.ginza import ginza
+from pilgram.hefe import hefe
+from pilgram.helena import helena
 from pilgram.hudson import hudson
 from pilgram.inkwell import inkwell
+from pilgram.juno import juno
 from pilgram.kelvin import kelvin
 from pilgram.lark import lark
 from pilgram.lofi import lofi
+from pilgram.ludwig import ludwig
 from pilgram.maven import maven
 from pilgram.mayfair import mayfair
 from pilgram.moon import moon
 from pilgram.nashville import nashville
 from pilgram.perpetua import perpetua
+from pilgram.poprocket import poprocket
 from pilgram.reyes import reyes
 from pilgram.rise import rise
+from pilgram.sierra import sierra
+from pilgram.skyline import skyline
 from pilgram.slumber import slumber
 from pilgram.stinson import stinson
+from pilgram.sutro import sutro
 from pilgram.toaster import toaster
 from pilgram.valencia import valencia
 from pilgram.walden import walden
@@ -44,25 +58,39 @@ __all__ = [
     "__version__",
     "_1977",
     "aden",
+    "amaro",
+    "ashby",
     "brannan",
     "brooklyn",
+    "charmes",
     "clarendon",
+    "crema",
+    "dogpatch",
     "earlybird",
     "gingham",
+    "ginza",
+    "hefe",
+    "helena",
     "hudson",
     "inkwell",
+    "juno",
     "kelvin",
     "lark",
     "lofi",
+    "ludwig",
     "maven",
     "mayfair",
     "moon",
     "nashville",
     "perpetua",
+    "poprocket",
     "reyes",
     "rise",
+    "sierra",
+    "skyline",
     "slumber",
     "stinson",
+    "sutro",
     "toaster",
     "valencia",
     "walden",

--- a/pilgram/aden.py
+++ b/pilgram/aden.py
@@ -32,7 +32,7 @@ def aden(im):
     cs = util.fill(cb.size, [66, 10, 14])
     cs = css.blending.darken(cb, cs)
 
-    alpha_mask = util.linear_gradient_mask(cb.size, start=0.8)
+    alpha_mask = util.linear_gradient_mask(cb.size, start=0.2)
     cr = Image.composite(cs, cb, alpha_mask)
 
     cr = css.hue_rotate(cr, -20)

--- a/pilgram/amaro.py
+++ b/pilgram/amaro.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def amaro(im):
+    """Applies Amaro filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    cs = util.fill(cb.size, [125, 105, 24, 0.1])
+
+    cr = css.blending.multiply(cb, cs)
+    cr = css.sepia(cr, 0.2)
+    cr = css.brightness(cr, 1.15)
+    cr = css.saturate(cr, 1.4)
+
+    return cr

--- a/pilgram/ashby.py
+++ b/pilgram/ashby.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def ashby(im):
+    """Applies Ashby filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    cs = util.fill(cb.size, [125, 105, 24, 0.35])
+
+    cr = css.blending.lighten(cb, cs)
+    cr = css.sepia(cr, 0.5)
+    cr = css.contrast(cr, 1.2)
+    cr = css.saturate(cr, 1.8)
+
+    return cr

--- a/pilgram/charmes.py
+++ b/pilgram/charmes.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def charmes(im):
+    """Applies Charmes filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    cs = util.fill(cb.size, [125, 105, 24, 0.25])
+
+    cr = css.blending.darken(cb, cs)
+    cr = css.sepia(cr, 0.25)
+    cr = css.contrast(cr, 1.25)
+    cr = css.brightness(cr, 1.25)
+    cr = css.saturate(cr, 1.35)
+    cr = css.hue_rotate(cr, -5)
+
+    return cr

--- a/pilgram/crema.py
+++ b/pilgram/crema.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def crema(im):
+    """Applies Crema filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    cs = util.fill(cb.size, [125, 105, 24, 0.25])
+
+    cr = css.blending.multiply(cb, cs)
+    cr = css.sepia(cr, 0.5)
+    cr = css.contrast(cr, 1.25)
+    cr = css.brightness(cr, 1.15)
+    cr = css.saturate(cr, 0.9)
+    cr = css.hue_rotate(cr, -2)
+
+    return cr

--- a/pilgram/dogpatch.py
+++ b/pilgram/dogpatch.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def dogpatch(im):
+    """Applies Dogpatch filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    cr = css.sepia(cb, 0.35)
+    cr = css.saturate(cr, 1.1)
+    cr = css.contrast(cr, 1.5)
+
+    return cr

--- a/pilgram/ginza.py
+++ b/pilgram/ginza.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def ginza(im):
+    """Applies Ginza filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    cs = util.fill(cb.size, [125, 105, 24, 0.15])
+
+    cr = css.blending.darken(cb, cs)
+    cr = css.sepia(cr, 0.25)
+    cr = css.contrast(cr, 1.15)
+    cr = css.brightness(cr, 1.2)
+    cr = css.saturate(cr, 1.35)
+    cr = css.hue_rotate(cr, -5)
+
+    return cr

--- a/pilgram/hefe.py
+++ b/pilgram/hefe.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def hefe(im):
+    """Applies Hefe filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    # position might not be 100% accurate
+    radial_gradient = util.radial_gradient(cb.size, [[0, 0, 0, 0], [0, 0, 0, 0.25]])
+
+    cr = css.blending.multiply(cb, radial_gradient)
+    cr = css.sepia(cr, 0.4)
+    cr = css.contrast(cr, 1.5)
+    cr = css.brightness(cr, 1.2)
+    cr = css.saturate(cr, 1.4)
+    cr = css.hue_rotate(cr, -10)
+
+    return cr

--- a/pilgram/helena.py
+++ b/pilgram/helena.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def helena(im):
+    """Applies Helena filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    cs = util.fill(cb.size, [158, 175, 30, 0.25])
+
+    cr = css.blending.overlay(cb, cs)
+    cr = css.sepia(cr, 0.5)
+    cr = css.contrast(cr, 1.05)
+    cr = css.brightness(cr, 1.05)
+    cr = css.saturate(cr, 1.35)
+
+    return cr

--- a/pilgram/juno.py
+++ b/pilgram/juno.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def juno(im):
+    """Applies Juno filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    cs = util.fill(cb.size, [127, 187, 227, 0.2])
+
+    cr = css.blending.overlay(cb, cs)
+    cr = css.sepia(cr, 0.35)
+    cr = css.contrast(cr, 1.15)
+    cr = css.brightness(cr, 1.15)
+    cr = css.saturate(cr, 1.8)
+
+    return cr

--- a/pilgram/ludwig.py
+++ b/pilgram/ludwig.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def ludwig(im):
+    """Applies ludwig filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    cs = util.fill(cb.size, [125, 105, 24, 0.1])
+
+    cr = css.blending.overlay(cb, cs)
+    cr = css.sepia(cr, 0.25)
+    cr = css.contrast(cr, 1.05)
+    cr = css.brightness(cr, 1.05)
+    cr = css.saturate(cr, 2)
+
+    return cr

--- a/pilgram/poprocket.py
+++ b/pilgram/poprocket.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def poprocket(im):
+    """Applies Poprocket filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    radial_gradient = util.radial_gradient(
+        cb.size, [[206, 39, 70, 0.75], [0, 0, 0, 0.0]], [0.4, 0.8]
+    )
+
+    cr = css.blending.screen(cb, radial_gradient)
+    cr = css.sepia(cr, 0.15)
+    cr = css.brightness(cr, 1.2)
+
+    return cr

--- a/pilgram/sierra.py
+++ b/pilgram/sierra.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def sierra(im):
+    """Applies Sierra filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    radial_gradient = util.radial_gradient(
+        cb.size, [[128, 78, 15, 0.5], [0, 0, 0, 0.65]]
+    )
+
+    cr = css.blending.screen(cb, radial_gradient)
+    cr = css.sepia(cr, 0.25)
+    cr = css.contrast(cr, 1.5)
+    cr = css.brightness(cr, 0.9)
+    cr = css.hue_rotate(cr, -15)
+
+    return cr

--- a/pilgram/skyline.py
+++ b/pilgram/skyline.py
@@ -1,0 +1,36 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def skyline(im):
+    """Applies Skyline filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    cr = css.sepia(cb, 0.15)
+    cr = css.contrast(cr, 1.25)
+    cr = css.brightness(cr, 1.25)
+    cr = css.saturate(cr, 1.2)
+
+    return cr

--- a/pilgram/sutro.py
+++ b/pilgram/sutro.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pilgram import css, util
+
+
+def sutro(im):
+    """Applies Sutro filter inspired by instagram.css
+
+    Arguments:
+        im: An input image.
+
+    Returns:
+        The output image.
+    """
+
+    cb = util.or_convert(im, "RGB")
+
+    radial_gradient = util.radial_gradient(
+        cb.size, [[0, 0, 0, 0], [0, 0, 0, 0.50]], [0.5, 0.9]
+    )
+
+    cr = css.blending.darken(cb, radial_gradient)
+    cr = css.sepia(cr, 0.4)
+    cr = css.contrast(cr, 1.2)
+    cr = css.brightness(cr, 0.9)
+    cr = css.saturate(cr, 1.4)
+    cr = css.hue_rotate(cr, -10)
+
+    return cr

--- a/pilgram/tests/test_1977.py
+++ b/pilgram/tests/test_1977.py
@@ -23,5 +23,5 @@ def test_1977():
 
 
 def test_1977_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(_1977, im)

--- a/pilgram/tests/test_aden.py
+++ b/pilgram/tests/test_aden.py
@@ -23,5 +23,5 @@ def test_aden():
 
 
 def test_aden_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(aden, im)

--- a/pilgram/tests/test_amaro.py
+++ b/pilgram/tests/test_amaro.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import amaro, util
+
+
+def test_amaro():
+    im = util.fill((32, 32), [255] * 3)
+    amaro(im)
+
+
+def test_amaro_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(amaro, im)

--- a/pilgram/tests/test_ashby.py
+++ b/pilgram/tests/test_ashby.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import ashby, util
+
+
+def test_ashby():
+    im = util.fill((32, 32), [255] * 3)
+    ashby(im)
+
+
+def test_ashby_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(ashby, im)

--- a/pilgram/tests/test_brannan.py
+++ b/pilgram/tests/test_brannan.py
@@ -23,5 +23,5 @@ def test_brannan():
 
 
 def test_brannan_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(brannan, im)

--- a/pilgram/tests/test_brooklyn.py
+++ b/pilgram/tests/test_brooklyn.py
@@ -23,5 +23,5 @@ def test_brooklyn():
 
 
 def test_brooklyn_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(brooklyn, im)

--- a/pilgram/tests/test_charmes.py
+++ b/pilgram/tests/test_charmes.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import charmes, util
+
+
+def test_charmes():
+    im = util.fill((32, 32), [255] * 3)
+    charmes(im)
+
+
+def test_charmes_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(charmes, im)

--- a/pilgram/tests/test_clarendon.py
+++ b/pilgram/tests/test_clarendon.py
@@ -23,5 +23,5 @@ def test_clarendon():
 
 
 def test_clarendon_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(clarendon, im)

--- a/pilgram/tests/test_crema.py
+++ b/pilgram/tests/test_crema.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import crema, util
+
+
+def test_crema():
+    im = util.fill((32, 32), [255] * 3)
+    crema(im)
+
+
+def test_crema_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(crema, im)

--- a/pilgram/tests/test_dogpatch.py
+++ b/pilgram/tests/test_dogpatch.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import dogpatch, util
+
+
+def test_dogpatch():
+    im = util.fill((32, 32), [255] * 3)
+    dogpatch(im)
+
+
+def test_dogpatch_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(dogpatch, im)

--- a/pilgram/tests/test_earlybird.py
+++ b/pilgram/tests/test_earlybird.py
@@ -23,5 +23,5 @@ def test_earlybird():
 
 
 def test_earlybird_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(earlybird, im)

--- a/pilgram/tests/test_gingham.py
+++ b/pilgram/tests/test_gingham.py
@@ -23,5 +23,5 @@ def test_gingham():
 
 
 def test_gingham_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(gingham, im)

--- a/pilgram/tests/test_ginza.py
+++ b/pilgram/tests/test_ginza.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import ginza, util
+
+
+def test_ginza():
+    im = util.fill((32, 32), [255] * 3)
+    ginza(im)
+
+
+def test_ginza_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(ginza, im)

--- a/pilgram/tests/test_hefe.py
+++ b/pilgram/tests/test_hefe.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import hefe, util
+
+
+def test_hefe():
+    im = util.fill((32, 32), [255] * 3)
+    hefe(im)
+
+
+def test_hefe_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(hefe, im)

--- a/pilgram/tests/test_helena.py
+++ b/pilgram/tests/test_helena.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import helena, util
+
+
+def test_helena():
+    im = util.fill((32, 32), [255] * 3)
+    helena(im)
+
+
+def test_helena_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(helena, im)

--- a/pilgram/tests/test_hudson.py
+++ b/pilgram/tests/test_hudson.py
@@ -23,5 +23,5 @@ def test_hudson():
 
 
 def test_hudson_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(hudson, im)

--- a/pilgram/tests/test_inkwell.py
+++ b/pilgram/tests/test_inkwell.py
@@ -23,5 +23,5 @@ def test_inkwell():
 
 
 def test_inkwell_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(inkwell, im)

--- a/pilgram/tests/test_juno.py
+++ b/pilgram/tests/test_juno.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import juno, util
+
+
+def test_juno():
+    im = util.fill((32, 32), [255] * 3)
+    juno(im)
+
+
+def test_juno_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(juno, im)

--- a/pilgram/tests/test_kelvin.py
+++ b/pilgram/tests/test_kelvin.py
@@ -23,5 +23,5 @@ def test_kelvin():
 
 
 def test_kelvin_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(kelvin, im)

--- a/pilgram/tests/test_lark.py
+++ b/pilgram/tests/test_lark.py
@@ -23,5 +23,5 @@ def test_lark():
 
 
 def test_lark_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(lark, im)

--- a/pilgram/tests/test_lofi.py
+++ b/pilgram/tests/test_lofi.py
@@ -23,5 +23,5 @@ def test_lofi():
 
 
 def test_lofi_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(lofi, im)

--- a/pilgram/tests/test_ludwig.py
+++ b/pilgram/tests/test_ludwig.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import ludwig, util
+
+
+def test_ludwig():
+    im = util.fill((32, 32), [255] * 3)
+    ludwig(im)
+
+
+def test_ludwig_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(ludwig, im)

--- a/pilgram/tests/test_maven.py
+++ b/pilgram/tests/test_maven.py
@@ -23,5 +23,5 @@ def test_maven():
 
 
 def test_maven_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(maven, im)

--- a/pilgram/tests/test_mayfair.py
+++ b/pilgram/tests/test_mayfair.py
@@ -23,5 +23,5 @@ def test_mayfair():
 
 
 def test_mayfair_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(mayfair, im)

--- a/pilgram/tests/test_moon.py
+++ b/pilgram/tests/test_moon.py
@@ -23,5 +23,5 @@ def test_moon():
 
 
 def test_moon_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(moon, im)

--- a/pilgram/tests/test_nashville.py
+++ b/pilgram/tests/test_nashville.py
@@ -23,5 +23,5 @@ def test_nashville():
 
 
 def test_nashville_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(nashville, im)

--- a/pilgram/tests/test_perpetua.py
+++ b/pilgram/tests/test_perpetua.py
@@ -23,5 +23,5 @@ def test_perpetua():
 
 
 def test_perpetua_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(perpetua, im)

--- a/pilgram/tests/test_poprocket.py
+++ b/pilgram/tests/test_poprocket.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import poprocket, util
+
+
+def test_poprocket():
+    im = util.fill((32, 32), [255] * 3)
+    poprocket(im)
+
+
+def test_poprocket_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(poprocket, im)

--- a/pilgram/tests/test_reyes.py
+++ b/pilgram/tests/test_reyes.py
@@ -23,5 +23,5 @@ def test_reyes():
 
 
 def test_reyes_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(reyes, im)

--- a/pilgram/tests/test_rise.py
+++ b/pilgram/tests/test_rise.py
@@ -23,5 +23,5 @@ def test_rise():
 
 
 def test_rise_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(rise, im)

--- a/pilgram/tests/test_sierra.py
+++ b/pilgram/tests/test_sierra.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import sierra, util
+
+
+def test_sierra():
+    im = util.fill((32, 32), [255] * 3)
+    sierra(im)
+
+
+def test_sierra_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(sierra, im)

--- a/pilgram/tests/test_skyline.py
+++ b/pilgram/tests/test_skyline.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import skyline, util
+
+
+def test_skyline():
+    im = util.fill((32, 32), [255] * 3)
+    skyline(im)
+
+
+def test_skyline_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(skyline, im)

--- a/pilgram/tests/test_slumber.py
+++ b/pilgram/tests/test_slumber.py
@@ -23,5 +23,5 @@ def test_slumber():
 
 
 def test_slumber_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(slumber, im)

--- a/pilgram/tests/test_stinson.py
+++ b/pilgram/tests/test_stinson.py
@@ -23,5 +23,5 @@ def test_stinson():
 
 
 def test_stinson_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(stinson, im)

--- a/pilgram/tests/test_sutro.py
+++ b/pilgram/tests/test_sutro.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Michael G.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from PIL import Image
+
+from pilgram import sutro, util
+
+
+def test_sutro():
+    im = util.fill((32, 32), [255] * 3)
+    sutro(im)
+
+
+def test_sutro_benchmark(benchmark):
+    with Image.open("examples/mtjimba.jpg") as im:
+        benchmark(sutro, im)

--- a/pilgram/tests/test_toaster.py
+++ b/pilgram/tests/test_toaster.py
@@ -23,5 +23,5 @@ def test_toaster():
 
 
 def test_toaster_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(toaster, im)

--- a/pilgram/tests/test_valencia.py
+++ b/pilgram/tests/test_valencia.py
@@ -23,5 +23,5 @@ def test_valencia():
 
 
 def test_valencia_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(valencia, im)

--- a/pilgram/tests/test_walden.py
+++ b/pilgram/tests/test_walden.py
@@ -23,5 +23,5 @@ def test_walden():
 
 
 def test_walden_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(walden, im)

--- a/pilgram/tests/test_willow.py
+++ b/pilgram/tests/test_willow.py
@@ -23,5 +23,5 @@ def test_willow():
 
 
 def test_willow_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(willow, im)

--- a/pilgram/tests/test_xpro2.py
+++ b/pilgram/tests/test_xpro2.py
@@ -23,5 +23,5 @@ def test_xpro2():
 
 
 def test_xpro2_benchmark(benchmark):
-    with Image.open("examples/mtjimba.jpg") as im:
+    with Image.open("notebooks/mtjimba.jpg") as im:
         benchmark(xpro2, im)

--- a/pilgram/util/linear_gradient.py
+++ b/pilgram/util/linear_gradient.py
@@ -15,35 +15,20 @@
 import numpy as np
 from PIL import Image
 
-from pilgram.util import fill, invert
+from pilgram.util import fill
 
 
-def _prepared_linear_gradient_mask(size, start, end, is_horizontal=True):
-    """Returns prepared linear gradient mask."""
-    assert end >= 1
-
-    mask = invert(Image.linear_gradient("L"))
-    w, h = mask.size
-    box = (0, round(h * start), w, round(h / end))
-    resized_mask = mask.resize(size, box=box)
-
-    if is_horizontal:
-        return resized_mask.rotate(90)
-    else:
-        return resized_mask
-
-
-def linear_gradient_mask(size, start=0, end=1, is_horizontal=True):
+def linear_gradient_mask(size, start=1, end=0, is_horizontal=True):
     """Creates mask image for linear gradient image.
 
     Arguments:
         size: A tuple/list of 2 integers. The size of output image.
         start: An optional integer/float. The starting point start.
             The point is left-side when `is_horizontal` is True, top otherwise.
-            Defaults to 0.
+            Defaults to 1.
         end: An optional integer/float. The ending point.
             The point is right-side when `is_horizontal` is True,
-            bottom otherwise. Defaults to 1.
+            bottom otherwise. Defaults to 0.
         is_horizontal: A optional boolean. The direction of gradient line.
             Left to right if True, top to bottom else.
 
@@ -55,9 +40,6 @@ def linear_gradient_mask(size, start=0, end=1, is_horizontal=True):
     """
 
     assert len(size) == 2
-
-    if end >= 1:
-        return _prepared_linear_gradient_mask(size, start, end, is_horizontal)
 
     w, h = size
     start *= 255

--- a/pilgram/util/radial_gradient.py
+++ b/pilgram/util/radial_gradient.py
@@ -105,7 +105,7 @@ def radial_gradient(size, colors, positions=None, **kwargs):
     assert len(size) == 2
     assert len(colors) >= 2
     for color in colors:
-        assert len(color) == 3
+        assert len(color) == 3 or len(color) == 4
 
     if positions is None:
         positions = np.linspace(0, 1, len(colors))

--- a/pilgram/util/tests/test_linear_gradient.py
+++ b/pilgram/util/tests/test_linear_gradient.py
@@ -17,24 +17,6 @@ from __future__ import division
 from pilgram import util
 
 
-def test_linear_gradient_mask_prepared_horizontal():
-    w, h = (4, 4)
-    mask = util.linear_gradient_mask((w, h))
-
-    assert list(mask.getdata()) == [222, 161, 94, 33] * h
-    assert mask.size == (w, h)
-    assert mask.mode == "L"
-
-
-def test_linear_gradient_mask_prepared_vertical():
-    w, h = (4, 4)
-    mask = util.linear_gradient_mask((w, h), is_horizontal=False)
-
-    assert list(mask.getdata()) == [222] * w + [161] * w + [94] * w + [33] * w
-    assert mask.size == (w, h)
-    assert mask.mode == "L"
-
-
 def test_linear_gradient_mask_start_end():
     w, h = (4, 4)
     start = 100 / 255
@@ -59,12 +41,58 @@ def test_linear_gradient_mask_start_end_vertical():
     assert mask.mode == "L"
 
 
-def test_linear_gradient_prepared():
+def test_linear_gradient():
     w, h = (4, 4)
-    white = [255] * 3
-    black = [0] * 3
-    gradient = util.linear_gradient((w, h), white, black)
-    expected_data = [(c,) * 3 for c in [222, 161, 94, 33]] * h
+    start = [255, 0, 0]  # red
+    end = [0, 0, 255]  # blue
+    gradient = util.linear_gradient((w, h), start, end)
+    expected_data = [
+        (255, 0, 0),
+        (170, 0, 85),
+        (85, 0, 170),
+        (0, 0, 255),
+        (255, 0, 0),
+        (170, 0, 85),
+        (85, 0, 170),
+        (0, 0, 255),
+        (255, 0, 0),
+        (170, 0, 85),
+        (85, 0, 170),
+        (0, 0, 255),
+        (255, 0, 0),
+        (170, 0, 85),
+        (85, 0, 170),
+        (0, 0, 255),
+    ]
+
+    assert list(gradient.getdata()) == expected_data
+    assert gradient.size == (w, h)
+    assert gradient.mode == "RGB"
+
+
+def test_linear_gradient_vertical():
+    w, h = (4, 4)
+    start = [255, 0, 0]  # red
+    end = [0, 0, 255]  # blue
+    gradient = util.linear_gradient((w, h), start, end, False)
+    expected_data = [
+        (255, 0, 0),
+        (255, 0, 0),
+        (255, 0, 0),
+        (255, 0, 0),
+        (170, 0, 85),
+        (170, 0, 85),
+        (170, 0, 85),
+        (170, 0, 85),
+        (85, 0, 170),
+        (85, 0, 170),
+        (85, 0, 170),
+        (85, 0, 170),
+        (0, 0, 255),
+        (0, 0, 255),
+        (0, 0, 255),
+        (0, 0, 255),
+    ]
 
     assert list(gradient.getdata()) == expected_data
     assert gradient.size == (w, h)


### PR DESCRIPTION
Hi,
I removed the _prepared version for linear_gradient since I found that there is no benefit in performance.
Left side is benchmark original, right side after my changes. Only aden and perpetua use the linear_gradient functions at all.

  | mean in ms |   |  
-- | -- | -- | --
Name | original | this patch request | delta | use linear_gradient(_mask)
test_inkwell_benchmark | 2,3 | 2,3 | 0,0 |  
test_toaster_benchmark | 3,9 | 4,0 | 0,1 |  
test_walden_benchmark | 4,7 | 4,3 | -0,4 |  
test_aden_benchmark | 4,9 | 4,8 | -0,2 | yes
test_valencia_benchmark | 5,3 | 5,6 | 0,2 |  
test_lofi_benchmark | 5,4 | 7,0 | 1,6 |  
test_brannan_benchmark | 7,6 | 8,4 | 0,8 |  
test_hudson_benchmark | 8,1 | 8,2 | 0,0 |  
test_1977_benchmark | 8,5 | 9,0 | 0,5 |  
test_moon_benchmark | 9,5 | 11,2 | 1,7 |  
test_gingham_benchmark | 10,4 | 14,6 | 4,2 |  
test_kelvin_benchmark | 12,9 | 10,6 | -2,3 |  
test_perpetua_benchmark | 11,1 | 11,1 | 0,0 | yes
test_clarendon_benchmark | 11,6 | 10,9 | -0,7 |  
test_reyes_benchmark | 12,4 | 12,4 | 0,0 |  
test_lark_benchmark | 14,7 | 15,4 | 0,6 |  
test_nashville_benchmark | 14,7 | 14,8 | 0,1 |  
test_stinson_benchmark | 15,5 | 16,9 | 1,3 |  
test_earlybird_benchmark | 15,8 | 15,5 | -0,3 |  
test_xpro2_benchmark | 19,4 | 19,6 | 0,2 |  
test_brooklyn_benchmark | 20,0 | 18,5 | -1,5 |  
test_slumber_benchmark | 23,3 | 21,1 | -2,1 |  
test_willow_benchmark | 27,5 | 27,2 | -0,3 |  
test_mayfair_benchmark | 26,2 | 37,8 | 11,6 |  
test_maven_benchmark | 33,3 | 34,3 | 1,0 |  
test_rise_benchmark | 34,8 | 33,1 | -1,7 |  



All tests ran well after my modifications (had to modify tests also for consistency) and my sample images I processed look fine also.